### PR TITLE
Several changes & fixes relating to LootTableModifiers

### DIFF
--- a/src/main/java/net/hecco/bountifulfares/BountifulFaresConfiguration.java
+++ b/src/main/java/net/hecco/bountifulfares/BountifulFaresConfiguration.java
@@ -170,6 +170,14 @@ public class BountifulFaresConfiguration {
         enableHoarySeeds = bool;
     }
 
+    public boolean isGrassLootTableOverride() {
+        return grassLootTableOverride;
+    }
+
+    public void setGrassLootTableOverride(boolean bool) {
+        grassLootTableOverride = bool;
+    }
+
     public boolean isEnableElderGuardianSpongekinSeeds() {
         return enableElderGuardianSpongekinSeeds;
     }

--- a/src/main/java/net/hecco/bountifulfares/config/Category.java
+++ b/src/main/java/net/hecco/bountifulfares/config/Category.java
@@ -37,8 +37,8 @@ public enum Category {
             Entry.booleanEntry("config.bountifulfares.lapisberry_seeds", () -> BountifulFares.CONFIG.isEnableLapisberrySeeds(),
                     newValue -> BountifulFares.CONFIG.setEnableLapisberrySeeds(newValue), true, "config.bountifulfares.restart_warning"),
 
-            Entry.booleanEntry("config.bountifulfares.grass_loot_table_override", () -> BountifulFares.CONFIG.grassLootTableOverride,
-                    newValue -> BountifulFares.CONFIG.grassLootTableOverride = newValue, true, "config.bountifulfares.restart_warning"),
+            Entry.booleanEntry("config.bountifulfares.grass_loot_table_override", () -> BountifulFares.CONFIG.isGrassLootTableOverride(),
+                    newValue -> BountifulFares.CONFIG.setGrassLootTableOverride(newValue), true, "config.bountifulfares.restart_warning"),
 
             Entry.booleanEntry("config.bountifulfares.spongekin_seeds_elder_guardian", () -> BountifulFares.CONFIG.isEnableElderGuardianSpongekinSeeds(),
                     newValue -> BountifulFares.CONFIG.setEnableElderGuardianSpongekinSeeds(newValue), true, "config.bountifulfares.restart_warning"),

--- a/src/main/java/net/hecco/bountifulfares/registry/misc/BFResourcePacks.java
+++ b/src/main/java/net/hecco/bountifulfares/registry/misc/BFResourcePacks.java
@@ -150,14 +150,14 @@ public class BFResourcePacks {
                     modContainer.get(),
                     Text.translatable("pack." + BountifulFares.MOD_ID + "." + "vanilla_item_override"),
                     ResourcePackActivationType.DEFAULT_ENABLED);
-            if (BountifulFares.CONFIG.grassLootTableOverride) {
-                ResourceManagerHelper.registerBuiltinResourcePack(
-                        Identifier.of(BountifulFares.MOD_ID, "grass_loot_table_override"),
-                        modContainer.get(),
-                        Text.translatable("pack." + BountifulFares.MOD_ID + "." + "grass_loot_table_override"),
-                        ResourcePackActivationType.ALWAYS_ENABLED
-                );
-            }
+            //if (BountifulFares.CONFIG.grassLootTableOverride) {
+            //    ResourceManagerHelper.registerBuiltinResourcePack(
+            //            Identifier.of(BountifulFares.MOD_ID, "grass_loot_table_override"),
+            //            modContainer.get(),
+            //            Text.translatable("pack." + BountifulFares.MOD_ID + "." + "grass_loot_table_override"),
+            //            ResourcePackActivationType.ALWAYS_ENABLED
+            //    );
+            //}
         }
     }
 }

--- a/src/main/java/net/hecco/bountifulfares/registry/util/BFLootTableModifiers.java
+++ b/src/main/java/net/hecco/bountifulfares/registry/util/BFLootTableModifiers.java
@@ -1,24 +1,37 @@
 package net.hecco.bountifulfares.registry.util;
 
-import net.fabricmc.fabric.api.loot.v2.LootTableEvents;
+import net.fabricmc.fabric.api.loot.v3.LootTableEvents;
 import net.hecco.bountifulfares.BountifulFares;
 import net.hecco.bountifulfares.registry.content.BFItems;
-import net.minecraft.data.server.loottable.BlockLootTableGenerator;
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.TallPlantBlock;
+import net.minecraft.block.enums.DoubleBlockHalf;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.Enchantments;
+import net.minecraft.item.Item;
 import net.minecraft.loot.LootPool;
 import net.minecraft.loot.LootTable;
-import net.minecraft.loot.condition.MatchToolLootCondition;
+import net.minecraft.loot.LootTables;
+import net.minecraft.loot.condition.BlockStatePropertyLootCondition;
+import net.minecraft.loot.condition.LocationCheckLootCondition;
+import net.minecraft.loot.condition.RandomChanceLootCondition;
+import net.minecraft.loot.condition.SurvivesExplosionLootCondition;
 import net.minecraft.loot.entry.EmptyEntry;
 import net.minecraft.loot.entry.ItemEntry;
-import net.minecraft.predicate.NumberRange;
-import net.minecraft.predicate.item.EnchantmentPredicate;
-import net.minecraft.predicate.item.EnchantmentsPredicate;
-import net.minecraft.predicate.item.ItemPredicate;
-import net.minecraft.predicate.item.ItemSubPredicateTypes;
+import net.minecraft.loot.entry.LootPoolEntry;
+import net.minecraft.loot.function.ApplyBonusLootFunction;
+import net.minecraft.loot.function.ExplosionDecayLootFunction;
+import net.minecraft.loot.function.SetCountLootFunction;
+import net.minecraft.loot.provider.number.ConstantLootNumberProvider;
+import net.minecraft.predicate.BlockPredicate;
+import net.minecraft.predicate.StatePredicate;
+import net.minecraft.predicate.entity.LocationPredicate;
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
 
 import java.util.List;
 
@@ -26,109 +39,151 @@ import static net.minecraft.data.server.loottable.BlockLootTableGenerator.WITH_S
 
 public class BFLootTableModifiers {
 
-    private static final Identifier GRASS_ID = Identifier.of("minecraft", "blocks/short_grass");
-    private static final Identifier TALL_GRASS_ID = Identifier.of("minecraft", "blocks/tall_grass");
-    private static final Identifier FERN_ID = Identifier.of("minecraft", "blocks/fern");
-    private static final Identifier LARGE_FERN_ID = Identifier.of("minecraft", "blocks/large_fern");
-    private static final Identifier SNIFFER_DIGGING_ID = Identifier.of("minecraft", "gameplay/sniffer_digging");
-    private static final Identifier ELDER_GUARDIAN_ID = Identifier.of("minecraft", "entities/elder_guardian");
-    private static final Identifier GUARDIAN_ID = Identifier.of("minecraft", "entities/guardian");
+    private static final RegistryKey<LootTable> SHORT_GRASS_ID = Blocks.SHORT_GRASS.getLootTableKey();
+    private static final RegistryKey<LootTable> TALL_GRASS_ID = Blocks.TALL_GRASS.getLootTableKey();
+    private static final RegistryKey<LootTable> FERN_ID = Blocks.FERN.getLootTableKey();
+    private static final RegistryKey<LootTable> LARGE_FERN_ID = Blocks.LARGE_FERN.getLootTableKey();
+
+    private static final RegistryKey<LootTable> GUARDIAN_ID = RegistryKey.of(
+            RegistryKeys.LOOT_TABLE, Identifier.ofVanilla("entities/guardian"));
+    private static final RegistryKey<LootTable> ELDER_GUARDIAN_ID = RegistryKey.of(
+            RegistryKeys.LOOT_TABLE, Identifier.ofVanilla("entities/elder_guardian"));
+
+    private static final RegistryKey<LootTable> SNIFFER_DIGGING_ID = LootTables.SNIFFER_DIGGING_GAMEPLAY;
+
     public static void modifyLootTables() {
-        LootTableEvents.REPLACE.register((key, original, source) -> {
-            if (GRASS_ID.equals(key.getValue())) {
-                LootPool.Builder poolBuilder = LootPool.builder()
-                        .with(ItemEntry.builder(BFItems.GRASS_SEEDS).weight(1))
-                        .with(EmptyEntry.builder().weight(5))
-                        .conditionally(WITH_SHEARS.invert());
+        // Prefetch all config settings for easier read
+        boolean do_lapisberries =                   BountifulFares.CONFIG.isEnableLapisberrySeeds();
+        boolean do_hoaryseeds =                     BountifulFares.CONFIG.isEnableHoarySeeds();
+        boolean do_spongekinseed_guardian =         BountifulFares.CONFIG.isEnableElderGuardianSpongekinSeeds();
+        boolean do_spongekinseed_elderguardian =    BountifulFares.CONFIG.isEnableElderGuardianSpongekinSeeds();
+        boolean do_grass_override =                 BountifulFares.CONFIG.isGrassLootTableOverride();
 
-                return mergePools(original, poolBuilder.build());
+        // Short Grass
+        LootTableEvents.REPLACE.register((key, original, source, wrapperLookup) -> {
+            if (SHORT_GRASS_ID.equals(key) && do_grass_override) {
+                return newGrassDropsShort(Blocks.SHORT_GRASS, BFItems.GRASS_SEEDS, wrapperLookup).build();
             }
-            return original;
+            return null;
         });
-
-        LootTableEvents.REPLACE.register((key, original, source) -> {
-            if (TALL_GRASS_ID.equals(key.getValue())) {
-                LootPool.Builder poolBuilder = LootPool.builder()
-                        .with(ItemEntry.builder(BFItems.GRASS_SEEDS).weight(1))
-                        .with(EmptyEntry.builder().weight(5))
-                        .conditionally(WITH_SHEARS.invert());
-
-                return mergePools(original, poolBuilder.build());
+        // Tall Grass
+        LootTableEvents.REPLACE.register((key, original, source, wrapperLookup) -> {
+            if (TALL_GRASS_ID.equals(key) && do_grass_override) {
+                return newGrassDropsTall(Blocks.TALL_GRASS, Blocks.SHORT_GRASS, BFItems.GRASS_SEEDS).build();
             }
-            return original;
+            return null;
         });
-
-        LootTableEvents.REPLACE.register((key, original, source) -> {
-            if (FERN_ID.equals(key.getValue())) {
-                LootPool.Builder poolBuilder = LootPool.builder()
-                        .with(ItemEntry.builder(BFItems.GRASS_SEEDS).weight(1))
-                        .with(EmptyEntry.builder().weight(5))
-                        .conditionally(WITH_SHEARS.invert());
-
-                return mergePools(original, poolBuilder.build());
+        // Short Fern
+        LootTableEvents.REPLACE.register((key, original, source, wrapperLookup) -> {
+            if (FERN_ID.equals(key) && do_grass_override) {
+                return newGrassDropsShort(Blocks.FERN, BFItems.GRASS_SEEDS, wrapperLookup).build();
             }
-            return original;
+            return null;
         });
-
-        LootTableEvents.REPLACE.register((key, original, source) -> {
-            if (LARGE_FERN_ID.equals(key.getValue())) {
-                LootPool.Builder poolBuilder = LootPool.builder()
-                        .with(ItemEntry.builder(BFItems.GRASS_SEEDS).weight(1))
-                        .with(EmptyEntry.builder().weight(5))
-                        .conditionally(WITH_SHEARS.invert());
-
-                return mergePools(original, poolBuilder.build());
+        // Large Fern
+        LootTableEvents.REPLACE.register((key, original, source, wrapperLookup) -> {
+            if (LARGE_FERN_ID.equals(key) && do_grass_override) {
+                return newGrassDropsTall(Blocks.LARGE_FERN, Blocks.FERN, BFItems.GRASS_SEEDS).build();
             }
-            return original;
+            return null;
         });
+        // Sniffer Digging table (registers only what is set in Config)
+        LootTableEvents.MODIFY.register((key, tableBuilder, source, wrapperLookup) -> {
+            if (SNIFFER_DIGGING_ID.equals(key)) {
 
-        if (BountifulFares.CONFIG.isEnableLapisberrySeeds()) {
-            LootTableEvents.MODIFY.register((key, tableBuilder, source) -> {
-                if (SNIFFER_DIGGING_ID.equals(key.getValue())) {
-                    tableBuilder.modifyPools(itemEntry -> {
-                        itemEntry.with((ItemEntry.builder(BFItems.LAPISBERRY_SEEDS)).build());
-                    });
-                }
-            });
-        }
+                // Lapisberries
+                if (do_lapisberries) tableBuilder.modifyPools(itemEntry -> {
+                    itemEntry.with((ItemEntry.builder(BFItems.LAPISBERRY_SEEDS)).build());
+                });
 
-        if (BountifulFares.CONFIG.isEnableHoarySeeds()) {
-            LootTableEvents.MODIFY.register((key, tableBuilder, source) -> {
-                if (SNIFFER_DIGGING_ID.equals(key.getValue())) {
-                    tableBuilder.modifyPools(itemEntry -> {
-                        itemEntry.with((ItemEntry.builder(BFItems.HOARY_SEEDS)).build());
-                    });
-                }
-            });
-        }
-
-        if (BountifulFares.CONFIG.isEnableElderGuardianSpongekinSeeds()) {
-            LootTableEvents.REPLACE.register((key, original, source) -> {
-                if (ELDER_GUARDIAN_ID.equals(key.getValue())) {
-                    LootPool.Builder poolBuilder = LootPool.builder()
-                            .with(ItemEntry.builder(BFItems.SPONGEKIN_SEEDS));
-
-                    return mergePools(original, poolBuilder.build());
-                }
-                return original;
-            });
-        }
-
-        if (BountifulFares.CONFIG.isEnableGuardianSpongekinSeeds()) {
-            LootTableEvents.REPLACE.register((key, original, source) -> {
-                if (GUARDIAN_ID.equals(key.getValue())) {
-                    LootPool.Builder poolBuilder = LootPool.builder()
-                            .with(ItemEntry.builder(BFItems.SPONGEKIN_SEEDS).weight(1))
-                            .with(EmptyEntry.builder().weight(5));
-
-                    return mergePools(original, poolBuilder.build());
-                }
-                return original;
-            });
-        }
+                // Hoary Seeds
+                if (do_hoaryseeds) tableBuilder.modifyPools(itemEntry -> {
+                    itemEntry.with((ItemEntry.builder(BFItems.HOARY_SEEDS)).build());
+                });
+            }
+        });
+        // Elder Guardian
+        LootTableEvents.MODIFY.register((key, original, source, wrapperLookup) -> {
+            if (ELDER_GUARDIAN_ID.equals(key) && do_spongekinseed_elderguardian) {
+                original.pool(LootPool.builder()
+                        .rolls(ConstantLootNumberProvider.create(1.0F))
+                        .with(ItemEntry.builder(BFItems.SPONGEKIN_SEEDS))
+                );
+            }
+        });
+        // Guardian
+        LootTableEvents.MODIFY.register((key, original, source, wrapperLookup) -> {
+            if (GUARDIAN_ID.equals(key) && do_spongekinseed_guardian) {
+                original.pool(LootPool.builder()
+                        .rolls(ConstantLootNumberProvider.create(1.0F))
+                        .with(ItemEntry.builder(BFItems.SPONGEKIN_SEEDS).weight(1))
+                        .with(EmptyEntry.builder().weight(5))
+                );
+            }
+        });
     }
+
+    @Deprecated
     private static LootTable mergePools(LootTable lootTable, LootPool lootPool) {
         lootPool = LootPool.builder().with(lootTable.pools.getFirst().entries).with(lootPool.entries).build();
         return LootTable.builder().pools(List.of(lootPool)).build();
+    }
+
+    /** A hacky, yet functional method of rebuilding short grass drops. Contains an input for the seed to drop as well. */
+    public static LootTable.Builder newGrassDropsShort(Block grass, Item seed, RegistryWrapper.WrapperLookup wrapper) {
+
+        RegistryWrapper.Impl<Enchantment> impl = wrapper.getWrapperOrThrow(RegistryKeys.ENCHANTMENT);
+
+        return LootTable.builder().pool(LootPool.builder()
+                .rolls(ConstantLootNumberProvider.create(1.0F))
+                .with(ItemEntry.builder(grass)
+                                .conditionally(WITH_SHEARS)
+                                .alternatively(ItemEntry.builder(seed)
+                                        .conditionally(RandomChanceLootCondition.builder(0.125F))
+                                        .apply(ExplosionDecayLootFunction.builder())
+                                        .apply(ApplyBonusLootFunction.uniformBonusCount(impl.getOrThrow(Enchantments.FORTUNE), 2)))
+                )
+        );
+    }
+
+    /** A method of rebuilding tall grass drops. Contains an input for the seed to drop as well. */
+    public static LootTable.Builder newGrassDropsTall(Block tallPlant, Block shortPlant, Item seed) {
+        LootPoolEntry.Builder<?> builder = ItemEntry.builder(shortPlant)
+                .apply(SetCountLootFunction.builder(ConstantLootNumberProvider.create(2.0F)))
+                .conditionally(WITH_SHEARS)
+                .alternatively(
+                        (ItemEntry.builder(seed)
+                                .conditionally(SurvivesExplosionLootCondition.builder())
+                                .conditionally(RandomChanceLootCondition.builder(0.125F)))
+                );
+        return LootTable.builder()
+                .pool(
+                        LootPool.builder()
+                                .with(builder)
+                                .conditionally(
+                                        BlockStatePropertyLootCondition.builder(tallPlant).properties(StatePredicate.Builder.create().exactMatch(TallPlantBlock.HALF, DoubleBlockHalf.LOWER))
+                                )
+                                .conditionally(
+                                        LocationCheckLootCondition.builder(
+                                                LocationPredicate.Builder.create()
+                                                        .block(BlockPredicate.Builder.create().blocks(tallPlant).state(StatePredicate.Builder.create().exactMatch(TallPlantBlock.HALF, DoubleBlockHalf.UPPER))),
+                                                new BlockPos(0, 1, 0)
+                                        )
+                                )
+                )
+                .pool(
+                        LootPool.builder()
+                                .with(builder)
+                                .conditionally(
+                                        BlockStatePropertyLootCondition.builder(tallPlant).properties(StatePredicate.Builder.create().exactMatch(TallPlantBlock.HALF, DoubleBlockHalf.UPPER))
+                                )
+                                .conditionally(
+                                        LocationCheckLootCondition.builder(
+                                                LocationPredicate.Builder.create()
+                                                        .block(BlockPredicate.Builder.create().blocks(tallPlant).state(StatePredicate.Builder.create().exactMatch(TallPlantBlock.HALF, DoubleBlockHalf.LOWER))),
+                                                new BlockPos(0, -1, 0)
+                                        )
+                                )
+                );
     }
 }


### PR DESCRIPTION
This pull request tweaks & fixes (or attempts to :'}) a small number of issues:

In `BFLootTableModifiers`:
- Updated FabricAPI's `LootTableEvents` from v2 to v3.
- Keys now use `RegistryKey<LootTable>` instead of `Identifier` for checking loot tables. This allows for direct pulling of loot table keys.
- Fixed a bug where Elder Guardians and Guardians wouldn't drop Spongekin Seeds regardless of config choices. This should also prevent them from trying to overwrite the Vanilla loot table completely.
- Properly fixed loot tables with grasses and ferns.
- Condensed Sniffer loot table check. It still only registers what's set in Config - just does it all in a single `LootTableEvent` now.
- Marked `mergePools()` as `@Deprecated`
	- This method, combined with the LootTableEvents.REPLACE, was actually the root cause of most of, if not all the aforementioned bugs; from the looks of it, the method attempted to do what `original.pool()` does on its own, but instead caused every unique pool to roll up into a single one.
	
Config:
- Made `grassLootTableOverride` private and added checker methods
- No longer requires a resource pack; now built into `BFLootTableModifiers`
	- Original code that handled this has been commented out instead of removed, just in case

From testing, this pull request fixes issues #30 and #37.