### PR TITLE
Implemented mixins for custom splashes & Note Block sounds

### DIFF
--- a/src/main/java/net/hecco/bountifulfares/mixin/NoteBlockInstrumentMixin.java
+++ b/src/main/java/net/hecco/bountifulfares/mixin/NoteBlockInstrumentMixin.java
@@ -1,0 +1,112 @@
+package net.hecco.bountifulfares.mixin;
+
+import net.hecco.bountifulfares.registry.content.BFSounds;
+import net.hecco.bountifulfares.registry.util.BFNoteBlockInstrument;
+import net.minecraft.block.enums.NoteBlockInstrument;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.sound.SoundEvent;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.gen.Invoker;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+// ID OF NOTEBLOCK FIELD: field_12652
+// Similar to GuiHeartsMixin, if this ever breaks, the field number can be found in the bytecode, and looks like this:
+// private final static synthetic [Lnet/minecraft/block/enums/NoteBlockInstrument; field_12652
+@Debug(export = true)
+@Mixin(NoteBlockInstrument.class)
+public abstract class NoteBlockInstrumentMixin
+{
+    // Allows new entries.
+    @SuppressWarnings("InvokerTarget")
+    @Invoker("<init>")
+    private static NoteBlockInstrument newNoteType(String internalName,
+                                                   int ordinal,
+                                                   String name,
+                                                   RegistryEntry<SoundEvent> sound,
+                                                   NoteBlockInstrument.Type type)
+    {
+        throw new AssertionError();
+    }
+
+    // Get note block field.
+    @SuppressWarnings("ShadowTarget")
+    @Shadow
+    private static @Final
+    @Mutable
+    NoteBlockInstrument[] field_12652;
+
+    // Injects data.
+    @SuppressWarnings("UnresolvedMixinReference")
+    @Inject(method = "<clinit>", at = @At(
+            value = "FIELD",
+            opcode = Opcodes.PUTSTATIC,
+            target = "Lnet/minecraft/block/enums/NoteBlockInstrument;field_12652:[Lnet/minecraft/block/enums/NoteBlockInstrument;",
+            shift = At.Shift.AFTER))
+    private static void customNoteBlockSFX(CallbackInfo ci)
+    {
+        // Get list of current note block sfx.
+        var notesounds = new ArrayList<>(Arrays.asList(field_12652));
+        var last = notesounds.get(notesounds.size() - 1);
+        var i = 1;
+
+        /*
+        The code section below is an example of how to implement a new Note Block sound.
+        Adding a new sound is similar to adding new heart types:
+
+            - Replace the var "bf_bonk" with a new one, then replace its usage in the last 2 lines with the new var.
+            - Change the internalName to "BOUNTIFUL_FARES_<new name>".
+            - Replace "bountiful_fares_bonk" with the ID for the sound.
+                - This will be referenced internally, and will show up if you change a Note Block's sound with a Debug Stick.
+            - Replace "BFSounds.NOTE_BLOCK_BONK_EXAMPLE" with any sound that's registered via RegistryEntry<SoundEvent>.
+                - BFSounds has a commented-out example of a custom Note Block sound for reference.
+            - Go to `BFNoteBlockInstrument` and define a new sound type. Replace "BOUNTIFUL_FARES_BONK" with your new one.
+
+        Also, check the comment at the bottom of this file for a handy reference for adding sounds to sounds.json, if it makes it easier.
+        ----------------------------------
+
+        // Bountiful Fares: Coconut Bonk
+        var bf_bonk = newNoteType(
+                "BOUNTIFUL_FARES_BONK",
+                last.ordinal() + i,
+                "bountiful_fares_bonk",
+                BFSounds.NOTE_BLOCK_BONK_EXAMPLE,
+                NoteBlockInstrument.Type.BASE_BLOCK
+        );
+        BFNoteBlockInstrument.BOUNTIFUL_FARES_BONK = bf_bonk;
+        notesounds.add(bf_bonk);
+        i++;
+
+        */
+
+        // Complete the injection.
+        // This must ALWAYS be executed at the end of this method - no more code beyond this.
+        field_12652 = notesounds.toArray(new NoteBlockInstrument[0]);
+    }
+
+    /*
+        The sounds folder should have a "note" folder for adding note sounds, similarly to Vanilla.
+        Below is a rough template for how you *could* register the notes in your sounds.json, including the common Vanilla subtitle.
+
+        ---------------------
+
+          "block.note_block.bountiful_fares.<NAME ID HERE>": {
+            "sounds": [
+              "frontiers:note/<SOUND NAME HERE>"
+            ],
+            "subtitle": "subtitles.block.note_block.note"
+          }
+
+        ---------------------
+
+        Also, small music theory-ish thing that you *might* already know: every single note block sound base is in F# key.
+        Recording your base sound in that key will make it match up with Vanilla sounds.
+
+        - artyrian :}
+     */
+}

--- a/src/main/java/net/hecco/bountifulfares/mixin/SplashMixin.java
+++ b/src/main/java/net/hecco/bountifulfares/mixin/SplashMixin.java
@@ -1,0 +1,77 @@
+package net.hecco.bountifulfares.mixin;
+
+import com.google.common.collect.Lists;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.hecco.bountifulfares.BountifulFares;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.resource.SplashTextResourceSupplier;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.profiler.Profiler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Mixin(SplashTextResourceSupplier.class)
+public abstract class SplashMixin
+{
+    @Unique private final List<String> bountifulFaresTexts = Lists.<String>newArrayList();
+    @Unique private static final Identifier BOUNTIFUL_FARES_ID = Identifier.of(BountifulFares.MOD_ID,"texts/splashes.txt");
+
+    @ModifyReturnValue(method = "prepare(Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/util/profiler/Profiler;)Ljava/util/List;", at = @At(value = "RETURN", ordinal = 0))
+    protected List<String> bountifulFaresSplashMix(List<String> original, @Local(argsOnly = true) ResourceManager resourceManager, @Local(argsOnly = true) Profiler profiler)
+    {
+        try {
+            BufferedReader bufferedReader = MinecraftClient.getInstance().getResourceManager().openAsReader(BOUNTIFUL_FARES_ID);
+
+            List<String> stringreader;
+            try {
+                stringreader = (List<String>)bufferedReader.lines().map(String::trim).filter(splashText -> splashText.hashCode() != 125780783).collect(Collectors.toList());
+            } catch (Throwable var7) {
+                if (bufferedReader != null) {
+                    try {
+                        bufferedReader.close();
+                    } catch (Throwable var6) {
+                        var7.addSuppressed(var6);
+                    }
+                }
+
+                throw var7;
+            }
+            if (bufferedReader != null) {
+                bufferedReader.close();
+            }
+
+            List<String> complete = original;
+            boolean worked = complete.addAll(stringreader);
+
+            if (worked)
+            {
+                //BountifulFares.LOGGER.info("Successfully mixed splash texts.");
+                return complete;
+            }
+            else
+            {
+                //BountifulFares.LOGGER.error("Unable to mix splash texts.");
+                return original;
+            }
+        } catch (IOException var8) {
+            return original;
+        }
+    }
+
+    @Inject(method = "apply(Ljava/util/List;Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/util/profiler/Profiler;)V", at = @At("TAIL"))
+    protected void applyNewSplashes(List<String> list, ResourceManager resourceManager, Profiler profiler, CallbackInfo ci)
+    {
+        this.bountifulFaresTexts.addAll(list);
+    }
+}

--- a/src/main/java/net/hecco/bountifulfares/registry/content/BFSounds.java
+++ b/src/main/java/net/hecco/bountifulfares/registry/content/BFSounds.java
@@ -3,6 +3,7 @@ package net.hecco.bountifulfares.registry.content;
 import net.hecco.bountifulfares.BountifulFares;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
+import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.sound.BlockSoundGroup;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;
@@ -63,6 +64,9 @@ public class BFSounds {
     public static final SoundEvent CABINET_OPEN = registerSoundEvent("cabinet_open");
     public static final SoundEvent CABINET_CLOSE = registerSoundEvent("cabinet_close");
 
+    // Note Block sounds MUST be registered as a RegistryEntry<SoundEvent>! Using registerSoundReference() will do this.
+    // The below sound is used in the example in NoteBlockInstrumentMixin. It can be deleted if necessary.
+    // public static final RegistryEntry<SoundEvent> NOTE_BLOCK_BONK_EXAMPLE = registerSoundReference("coconut_bonk");
 
     public static final BlockSoundGroup CERAMIC_TILES = new BlockSoundGroup(1f, 1f, CERAMIC_TILES_BREAK, CERAMIC_TILES_STEP, CERAMIC_TILES_PLACE, CERAMIC_TILES_HIT, CERAMIC_TILES_FALL);
     public static final BlockSoundGroup CERAMIC_DECORATION = new BlockSoundGroup(1f, 1f, CERAMIC_DECORATION_BREAK, CERAMIC_DECORATION_STEP, CERAMIC_DECORATION_PLACE, CERAMIC_DECORATION_HIT, CERAMIC_DECORATION_FALL);
@@ -73,9 +77,10 @@ public class BFSounds {
     public static final BlockSoundGroup SPONGEKIN = new BlockSoundGroup(1f, 1.1f, SPONGEKIN_BREAK, SPONGEKIN_STEP, SPONGEKIN_PLACE, SoundEvents.BLOCK_WOOD_HIT, SoundEvents.BLOCK_WOOD_FALL);
     public static final BlockSoundGroup COIR = new BlockSoundGroup(1f, 1f, COIR_BREAK, COIR_STEP, COIR_PLACE, COIR_HIT, COIR_FALL);
 
-
-
-
+    private static RegistryEntry.Reference<SoundEvent> registerSoundReference(String name) {
+        Identifier id = Identifier.of(BountifulFares.MOD_ID, name);
+        return Registry.registerReference(Registries.SOUND_EVENT, id, SoundEvent.of(id));
+    }
 
     public static SoundEvent registerSoundEvent(String name) {
         Identifier identifier = Identifier.of(BountifulFares.MOD_ID, name);

--- a/src/main/java/net/hecco/bountifulfares/registry/util/BFNoteBlockInstrument.java
+++ b/src/main/java/net/hecco/bountifulfares/registry/util/BFNoteBlockInstrument.java
@@ -1,0 +1,22 @@
+package net.hecco.bountifulfares.registry.util;
+
+import net.minecraft.block.enums.NoteBlockInstrument;
+
+// Loads Note Block types
+public class BFNoteBlockInstrument
+{
+    // This solely ensures the class remains loaded.
+    static {
+        NoteBlockInstrument.values();
+    }
+
+    // Here you can define new note block sound types.
+    // When defining .instrument() on a block, you can use one of these instead of a sound from NoteBlockInstrument.
+    // "BOUNTIFUL_FARES_BONK" is a commented-out example; see its registry code in NoteBlockInstrumentMixin.
+    public static NoteBlockInstrument BOUNTIFUL_FARES_BONK;
+
+    /*
+        To add a new Note Block sound, simply create a new 'public static' like the commented out code shows.
+        NoteBlockInstrumentMixin has more info on this process - you'll reference your new variable there.
+    */
+}

--- a/src/main/resources/bountifulfares.accesswidener
+++ b/src/main/resources/bountifulfares.accesswidener
@@ -6,3 +6,5 @@ accessible field net/minecraft/loot/LootTable pools Ljava/util/List;
 
 accessible class net/minecraft/structure/WoodlandMansionGenerator$FirstFloorRoomPool
 accessible class net/minecraft/structure/WoodlandMansionGenerator$SecondFloorRoomPool
+
+accessible class net/minecraft/block/enums/NoteBlockInstrument$Type

--- a/src/main/resources/bountifulfares.mixins.json
+++ b/src/main/resources/bountifulfares.mixins.json
@@ -13,6 +13,7 @@
     "ItemRendererMixin",
     "LivingEntityMixin",
     "ModelLoaderMixin",
+    "NoteBlockInstrumentMixin",
     "SweetBerryBushMixin",
     "WolfEntityMixin",
     "WoodlandMansionFirstFloorMixin",
@@ -22,6 +23,7 @@
     "defaultRequire": 1
   },
   "client": [
-    "GuiHeartsMixin"
+    "GuiHeartsMixin",
+    "SplashMixin"
   ]
 }


### PR DESCRIPTION
This pull request implements mixins for both custom/unique splash text (`SplashMixin`) & custom note block sounds (`NoteBlockInstrumentMixin` & `BFNoteBlockInstrument` + 1 access widener).

---------------------------------------
`SplashMixin` allows Bountiful Fares to provide its own unique splash text if it's ever desired in the future. These splashes don't overwrite Vanilla splashes, and when tested with another mod which has custom splashes via the same implementation, both unique splashes seamlessly mixed together instead of overwriting; logically speaking, this means other splash mixins (at least if they're using `@ModifyReturnValue` like they probably should) should work with this too.

It doesn't have support for localization; ironically, neither does Vanilla's, so it's not really a glaring issue.

The text file is located at `assets/bountifulfares/texts/splashes.txt` - it is currently empty. Adding new splashes is as simple as writing lines in this file, and each new line is a new splash. Below is an example splash used during testing, confirming the mixin works:

![image](https://github.com/user-attachments/assets/ef717d49-9601-41b7-a9e4-6ed4946c0e41)

---------------------------------------
Alongside that, this pull request also implements custom Note Block sound support by mixing into the `NoteBlockInstrument` enum, similarly to how my previous pull request did for updated Restoration rendering (#52). These new instruments can be applied to new blocks defined by Bountiful Fares; it's FAR more difficult to modify Vanilla blocks to use them.

The process is less straightforward than the splash mixin, however. As such, I've provided (hopefully legible :'}) examples & documentation on how to implement custom Note Block sounds, which should make adding them a breeze. These can be found in `NoteBlockInstrumentMixin` and `BFNoteBlockInstrument`.

I also added the method `registerSoundReference()` to `BFSounds` in order to facilitate Note Block sound additions, since they require a direct `RegistryEntry` reference. It also contains a commented-out register for the example Note Block sound.

Below is an example of the mixin in action (prior to the content being commented out). It works seamlessly with Vanilla sounds, and stacks with sounds implemented by other mods. **(Video has sound)**

https://github.com/user-attachments/assets/809bc27b-938c-4b69-a126-a3a0e2dfc54b

---------------------------------------
I've tested these changes in the following environments, which all passed testing:
- By itself (IntelliJ environment)
- Together with my own mod - which had the same implementations & merged seamlessly
- Prism Launcher 1.21.1 - 31 active mods
- NeoForge 1.21.1 w/ Sinytra Converter
---------------------------------------
I avoided listing these in the changelog since they're implementations rather than actual new features. Hopefully they're of some use to you at least. :}