### PR TITLE
Updated fabric.mod.json to include mixin::init for enums

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,9 @@
 		"fabric-datagen": [
 			"net.hecco.bountifulfares.BountifulFaresDataGenerator"
 		],
+		"preLaunch": [
+			"com.llamalad7.mixinextras.MixinExtrasBootstrap::init"
+		],
 		"modmenu": [
 			"net.hecco.bountifulfares.config.BountifulFaresModMenu"
 		],


### PR DESCRIPTION
Got word of a crash log detailing a crash involving my mixins; upon further inspection, I forgot to put `MixinExtrasBootstrap::init` into the `fabric.mod.json`. This, to my knowledge, is actually what allows these enums to work in the first place, and the only reason it worked on my tests is because the init was called by other mods - at least I hope so. :'}

If this doesn't fix this issue I will continue to look into the cause, sorry again.